### PR TITLE
add logging to outage

### DIFF
--- a/lib/get-outages.ts
+++ b/lib/get-outages.ts
@@ -64,6 +64,6 @@ export const getOutages = (checks: StatusCheck[]) => {
       })
     }
   }
-
+  console.log(`Detected Outages:` , outages)
   return outages
 }

--- a/scripts/run-checks-and-write-log.ts
+++ b/scripts/run-checks-and-write-log.ts
@@ -20,10 +20,11 @@ async function runChecksAndWriteLog() {
 
   const results = await Promise.all(
     checks.map(async (check) => {
-      console.log(`Running health checks for ${check.name}`);
+      console.log(`Running health checks for ${check.name}...`)
       
-      const result = await check.fn()
-      console.log(`Result for ${check.name}: ${result}`);
+      const result = await check.fn();
+      console.log(`Result for ${check.name}:`, result)
+
       if (!result.ok) {
         console.error(
           `${check.name} health check failed: ${result.error.message}`,
@@ -55,6 +56,7 @@ async function runChecksAndWriteLog() {
     .map((line) => JSON.parse(line))
     .filter((log: StatusCheck) => new Date(log.timestamp) >= twoWeeksAgo)
 
+  console.log("Pruning old logs, keeping recent entries only...")
   await Bun.write(
     "./statuses.jsonl",
     recentLogs.map((log) => JSON.stringify(log)).join("\n") + "\n",

--- a/scripts/run-checks-and-write-log.ts
+++ b/scripts/run-checks-and-write-log.ts
@@ -20,7 +20,10 @@ async function runChecksAndWriteLog() {
 
   const results = await Promise.all(
     checks.map(async (check) => {
+      console.log(`Running health checks for ${check.name}`);
+      
       const result = await check.fn()
+      console.log(`Result for ${check.name}: ${result}`);
       if (!result.ok) {
         console.error(
           `${check.name} health check failed: ${result.error.message}`,

--- a/status-checks/check-snippets-playwright-test-health.ts
+++ b/status-checks/check-snippets-playwright-test-health.ts
@@ -1,3 +1,4 @@
+
 import type { HealthCheckFunction } from "./types"
 import ky from "ky"
 
@@ -12,11 +13,15 @@ export const checkSnippetsPlaywrightTestHealth: HealthCheckFunction =
         })
         .json<{ check_runs: Array<{ status: string; conclusion: string }> }>()
 
+        checksRes.check_runs.forEach((check) => {
+          console.log(`Status: ${check.status}, Conclusion: ${check.conclusion}`);
+          
+        })
       const allChecksComplete = checksRes.check_runs.every(
         (check) => check.status === "completed",
       )
       const allChecksPassing = checksRes.check_runs.every(
-        (check) => check.conclusion === "success",
+        (check) => check.conclusion === "success" || check.conclusion === "skipped",
       )
 
       if (!allChecksComplete || !allChecksPassing) {


### PR DESCRIPTION
/claim #2 
Fixes #2 

### Reference screenshots:

![Screenshot from 2025-01-06 15-55-13](https://github.com/user-attachments/assets/6732a746-337d-4553-b75b-5eb8d44e9ec1)

```bash
➜  maintenance-tracker git:(outage) bun run start
$ bun run scripts/run-checks-and-write-log.ts && bun run scripts/generate-site.tsx && open public/index.html
Status: completed, Conclusion: skipped
Status: completed, Conclusion: skipped
Status: completed, Conclusion: skipped
Status: completed, Conclusion: skipped
Status: completed, Conclusion: success
Status: completed, Conclusion: success
Status: completed, Conclusion: success
Status: completed, Conclusion: success
Status: completed, Conclusion: success
reading statuses...
found 1321 checks
computing service outages...
found 3 outages
rendering html...
rendering status grid...
rendering uptime graph... 252
writing to ./public/index.html...
➜  maintenance-tracker git:(outage) ✗ 

```

